### PR TITLE
LPFG-586: adding config for new management

### DIFF
--- a/environments/demo/main.tf
+++ b/environments/demo/main.tf
@@ -286,3 +286,25 @@ module "civil-servant-registry-service" {
   envurl                      = "${var.envurl}"
   authentication_service_url  = "https://${var.envurl}identity.cshr.digital"
 }
+
+module "lpg-management2" {
+  source                              = "../../modules/lpg-management2"
+  rg_name                             = "${var.rg_name}"
+  rg_prefix                           = "${var.rg_prefix}"
+  rg_location                         = "${var.rg_location}"
+  docker_tag                          = "${var.lpg_management2_tag}"
+  lpg_management2_name                 = "${var.rg_prefix}-${var.rg_name}-${var.lpg_management2_name}"
+  authentication_service_url          = "https://${var.envurl}identity.cshr.digital"
+  env_profile                         = "${var.env_profile}"
+  session_secret                      = "${var.session_secret}"
+  hammer_working_directory            = "${var.management2_hammer_working_directory}"
+  websites_port                       = "${var.management2_websites_port}"
+  vaultresourcegroup                  = "${var.vaultresourcegroup}"
+  vaultname                           = "${var.vaultname}"
+  existingkeyvaultsecretname          = "${var.existingkeyvaultsecretname}"
+  certificatename                     = "${var.certificatename}"
+  envurl                              = "${var.envurl}"
+  lpg_management2_oauth_client_id      = "${var.lpg_management2_oauth_client_id}"
+  lpg_management2_oauth_client_secret  = "${var.lpg_management2_oauth_client_secret}"
+  callback_url                        = "${var.callback_url}"
+}

--- a/environments/demo/main.tf
+++ b/environments/demo/main.tf
@@ -297,8 +297,8 @@ module "lpg-management2" {
   authentication_service_url          = "https://${var.envurl}identity.cshr.digital"
   env_profile                         = "${var.env_profile}"
   session_secret                      = "${var.session_secret}"
-  hammer_working_directory            = "${var.management2_hammer_working_directory}"
-  websites_port                       = "${var.management2_websites_port}"
+  hammer_working_directory            = "${var.lpg_management2_hammer_working_directory}"
+  websites_port                       = "${var.lpg_management2_websites_port}"
   vaultresourcegroup                  = "${var.vaultresourcegroup}"
   vaultname                           = "${var.vaultname}"
   existingkeyvaultsecretname          = "${var.existingkeyvaultsecretname}"
@@ -306,5 +306,5 @@ module "lpg-management2" {
   envurl                              = "${var.envurl}"
   lpg_management2_oauth_client_id      = "${var.lpg_management2_oauth_client_id}"
   lpg_management2_oauth_client_secret  = "${var.lpg_management2_oauth_client_secret}"
-  callback_url                        = "${var.callback_url}"
+  callback_url                        = "${var.lpg_management2_callback_url}"
 }

--- a/environments/demo/vars.tf
+++ b/environments/demo/vars.tf
@@ -71,6 +71,10 @@ variable "lpg_report_service_docker_tag" {
   default = "f15aad08b44f0d7dbc3e067a61fcf7341359c0ef"
 }
 
+variable "lpg_management2_tag" {
+  default = "latest"
+}
+
 ### cosmos ###
 variable "cosmos_name" {
   default = "cosmos"
@@ -211,4 +215,22 @@ variable "report_service_websites_port" {
 
 variable "identity_management_name" {
   default = "identity-management"
+}
+
+
+### lpg-management2 ###
+variable "lpg_management2_name" {
+  default = "lpg-management2"
+}
+
+variable "management2_hammer_working_directory" {
+  default = "/var/www/app/dist/management2"
+}
+
+variable "management2_websites_port" {
+  default = "3005"
+}
+
+variable "callback_url" {
+  default = "https://lpg-lpgdemo2-lpg-management2.azurewebsites.net"
 }

--- a/environments/demo/vars.tf
+++ b/environments/demo/vars.tf
@@ -223,14 +223,14 @@ variable "lpg_management2_name" {
   default = "lpg-management2"
 }
 
-variable "management2_hammer_working_directory" {
+variable "lpg_management2_hammer_working_directory" {
   default = "/var/www/app/dist/management2"
 }
 
-variable "management2_websites_port" {
+variable "lpg_management2_websites_port" {
   default = "3005"
 }
 
-variable "callback_url" {
+variable "lpg_management2_callback_url" {
   default = "https://lpg-lpgdemo2-lpg-management2.azurewebsites.net"
 }

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -213,6 +213,28 @@ module "lpg-management" {
   report_service_url                  = "https://${var.envurl}report.cshr.digital"
 }
 
+module "lpg-management2" {
+  source                              = "../../modules/lpg-management2"
+  rg_name                             = "${var.rg_name}"
+  rg_prefix                           = "${var.rg_prefix}"
+  rg_location                         = "${var.rg_location}"
+  docker_tag                          = "${var.lpg_management2_tag}"
+  lpg_management2_name                 = "${var.rg_prefix}-${var.rg_name}-${var.lpg_management2_name}"
+  authentication_service_url          = "https://${var.envurl}identity.cshr.digital"
+  env_profile                         = "${var.env_profile}"
+  session_secret                      = "${var.session_secret}"
+  hammer_working_directory            = "${var.management2_hammer_working_directory}"
+  websites_port                       = "${var.management2_websites_port}"
+  vaultresourcegroup                  = "${var.vaultresourcegroup}"
+  vaultname                           = "${var.vaultname}"
+  existingkeyvaultsecretname          = "${var.existingkeyvaultsecretname}"
+  certificatename                     = "${var.certificatename}"
+  envurl                              = "${var.envurl}"
+  lpg_management2_oauth_client_id      = "${var.lpg_management2_oauth_client_id}"
+  lpg_management2_oauth_client_secret  = "${var.lpg_management2_oauth_client_secret}"
+  callback_url                        = "${var.callback_url}"
+}
+
 module "lpg-ui" {
   source                          = "../../modules/lpg-ui"
   rg_name                         = "${var.rg_name}"

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -213,28 +213,6 @@ module "lpg-management" {
   report_service_url                  = "https://${var.envurl}report.cshr.digital"
 }
 
-module "lpg-management2" {
-  source                              = "../../modules/lpg-management2"
-  rg_name                             = "${var.rg_name}"
-  rg_prefix                           = "${var.rg_prefix}"
-  rg_location                         = "${var.rg_location}"
-  docker_tag                          = "${var.lpg_management2_tag}"
-  lpg_management2_name                 = "${var.rg_prefix}-${var.rg_name}-${var.lpg_management2_name}"
-  authentication_service_url          = "https://${var.envurl}identity.cshr.digital"
-  env_profile                         = "${var.env_profile}"
-  session_secret                      = "${var.session_secret}"
-  hammer_working_directory            = "${var.management2_hammer_working_directory}"
-  websites_port                       = "${var.management2_websites_port}"
-  vaultresourcegroup                  = "${var.vaultresourcegroup}"
-  vaultname                           = "${var.vaultname}"
-  existingkeyvaultsecretname          = "${var.existingkeyvaultsecretname}"
-  certificatename                     = "${var.certificatename}"
-  envurl                              = "${var.envurl}"
-  lpg_management2_oauth_client_id      = "${var.lpg_management2_oauth_client_id}"
-  lpg_management2_oauth_client_secret  = "${var.lpg_management2_oauth_client_secret}"
-  callback_url                        = "${var.callback_url}"
-}
-
 module "lpg-ui" {
   source                          = "../../modules/lpg-ui"
   rg_name                         = "${var.rg_name}"
@@ -307,4 +285,26 @@ module "civil-servant-registry-service" {
   gov_notify_api_key          = "${var.gov_notify_api_key}"
   envurl                      = "${var.envurl}"
   authentication_service_url  = "https://${var.envurl}identity.cshr.digital"
+}
+
+module "lpg-management2" {
+  source                              = "../../modules/lpg-management2"
+  rg_name                             = "${var.rg_name}"
+  rg_prefix                           = "${var.rg_prefix}"
+  rg_location                         = "${var.rg_location}"
+  docker_tag                          = "${var.lpg_management2_tag}"
+  lpg_management2_name                 = "${var.rg_prefix}-${var.rg_name}-${var.lpg_management2_name}"
+  authentication_service_url          = "https://${var.envurl}identity.cshr.digital"
+  env_profile                         = "${var.env_profile}"
+  session_secret                      = "${var.session_secret}"
+  hammer_working_directory            = "${var.lpg_management2_hammer_working_directory}"
+  websites_port                       = "${var.lpg_management2_websites_port}"
+  vaultresourcegroup                  = "${var.vaultresourcegroup}"
+  vaultname                           = "${var.vaultname}"
+  existingkeyvaultsecretname          = "${var.existingkeyvaultsecretname}"
+  certificatename                     = "${var.certificatename}"
+  envurl                              = "${var.envurl}"
+  lpg_management2_oauth_client_id      = "${var.lpg_management2_oauth_client_id}"
+  lpg_management2_oauth_client_secret  = "${var.lpg_management2_oauth_client_secret}"
+  callback_url                        = "${var.lpg_management2_callback_url}"
 }

--- a/environments/dev/vars.tf
+++ b/environments/dev/vars.tf
@@ -59,10 +59,6 @@ variable "lpg_services_tag" {
   default = "latest"
 }
 
-variable "lpg_management2_tag" {
-  default = "latest"
-}
-
 variable "learning_catalogue_docker_tag" {
   default = "91135d7833b3aa0028f43cc6f593d9f80fc15a57"
 }
@@ -73,6 +69,10 @@ variable "civil_servant_registry_docker_tag" {
 
 variable "lpg_report_service_docker_tag" {
   default = "f15aad08b44f0d7dbc3e067a61fcf7341359c0ef"
+}
+
+variable "lpg_management2_tag" {
+  default = "latest"
 }
 
 ### cosmos ###
@@ -176,23 +176,6 @@ variable "management_ui_websites_port" {
   default = "3001"
 }
 
-### lpg-management2 ###
-variable "lpg_management2_name" {
-  default = "lpg-management2"
-}
-
-variable "management2_hammer_working_directory" {
-  default = "/var/www/app/dist/management2"
-}
-
-variable "management2_websites_port" {
-  default = "3005"
-}
-
-variable "callback_url" {
-  default = "https://lpg-lpgdev2-lpg-management2.azurewebsites.net"
-}
-
 ### lpg-ui ###
 variable "lpg_ui_name" {
   default = "lpg-ui"
@@ -231,4 +214,21 @@ variable "report_service_websites_port" {
 
 variable "identity_management_name" {
   default = "identity-management"
+}
+
+### lpg-management2 ###
+variable "lpg_management2_name" {
+  default = "lpg-management2"
+}
+
+variable "management2_hammer_working_directory" {
+  default = "/var/www/app/dist/management2"
+}
+
+variable "management2_websites_port" {
+  default = "3005"
+}
+
+variable "callback_url" {
+  default = "https://lpg-lpgdev2-lpg-management2.azurewebsites.net"
 }

--- a/environments/dev/vars.tf
+++ b/environments/dev/vars.tf
@@ -221,14 +221,14 @@ variable "lpg_management2_name" {
   default = "lpg-management2"
 }
 
-variable "management2_hammer_working_directory" {
+variable "lpg_management2_hammer_working_directory" {
   default = "/var/www/app/dist/management2"
 }
 
-variable "management2_websites_port" {
+variable "lpg_management2_websites_port" {
   default = "3005"
 }
 
-variable "callback_url" {
+variable "lpg_management2_callback_url" {
   default = "https://lpg-lpgdev2-lpg-management2.azurewebsites.net"
 }

--- a/environments/dev/vars.tf
+++ b/environments/dev/vars.tf
@@ -44,7 +44,7 @@ variable "google_analytics_id" {
 
 ### docker tags ###
 variable "identity_docker_tag" {
-  default = "0eb6e0e490c3f90cd79c17092980c533913c4faa"
+  default = "e4aff54943f71dd6b270b33175606f7884a54ccb"
 }
 
 variable "lpg_learner_record_docker_tag" {
@@ -56,6 +56,10 @@ variable "ll_docker_tag" {
 }
 
 variable "lpg_services_tag" {
+  default = "latest"
+}
+
+variable "lpg_management2_tag" {
   default = "latest"
 }
 
@@ -170,6 +174,23 @@ variable "management_ui_hammer_working_directory" {
 
 variable "management_ui_websites_port" {
   default = "3001"
+}
+
+### lpg-management2 ###
+variable "lpg_management2_name" {
+  default = "lpg-management2"
+}
+
+variable "management2_hammer_working_directory" {
+  default = "/var/www/app/dist/management2"
+}
+
+variable "management2_websites_port" {
+  default = "3005"
+}
+
+variable "callback_url" {
+  default = "https://lpg-lpgdev2-lpg-management2.azurewebsites.net"
 }
 
 ### lpg-ui ###

--- a/environments/test/main.tf
+++ b/environments/test/main.tf
@@ -298,8 +298,8 @@ module "lpg-management2" {
   authentication_service_url          = "https://${var.envurl}identity.cshr.digital"
   env_profile                         = "${var.env_profile}"
   session_secret                      = "${var.session_secret}"
-  hammer_working_directory            = "${var.management2_hammer_working_directory}"
-  websites_port                       = "${var.management2_websites_port}"
+  hammer_working_directory            = "${var.lpg_management2_hammer_working_directory}"
+  websites_port                       = "${var.lpg_management2_websites_port}"
   vaultresourcegroup                  = "${var.vaultresourcegroup}"
   vaultname                           = "${var.vaultname}"
   existingkeyvaultsecretname          = "${var.existingkeyvaultsecretname}"
@@ -307,5 +307,5 @@ module "lpg-management2" {
   envurl                              = "${var.envurl}"
   lpg_management2_oauth_client_id      = "${var.lpg_management2_oauth_client_id}"
   lpg_management2_oauth_client_secret  = "${var.lpg_management2_oauth_client_secret}"
-  callback_url                        = "${var.callback_url}"
+  callback_url                        = "${var.lpg_management2_callback_url}"
 }

--- a/environments/test/main.tf
+++ b/environments/test/main.tf
@@ -287,3 +287,25 @@ module "civil-servant-registry-service" {
   envurl                      = "${var.envurl}"
   authentication_service_url  = "https://${var.envurl}identity.cshr.digital"
 }
+
+module "lpg-management2" {
+  source                              = "../../modules/lpg-management2"
+  rg_name                             = "${var.rg_name}"
+  rg_prefix                           = "${var.rg_prefix}"
+  rg_location                         = "${var.rg_location}"
+  docker_tag                          = "${var.lpg_management2_tag}"
+  lpg_management2_name                 = "${var.rg_prefix}-${var.rg_name}-${var.lpg_management2_name}"
+  authentication_service_url          = "https://${var.envurl}identity.cshr.digital"
+  env_profile                         = "${var.env_profile}"
+  session_secret                      = "${var.session_secret}"
+  hammer_working_directory            = "${var.management2_hammer_working_directory}"
+  websites_port                       = "${var.management2_websites_port}"
+  vaultresourcegroup                  = "${var.vaultresourcegroup}"
+  vaultname                           = "${var.vaultname}"
+  existingkeyvaultsecretname          = "${var.existingkeyvaultsecretname}"
+  certificatename                     = "${var.certificatename}"
+  envurl                              = "${var.envurl}"
+  lpg_management2_oauth_client_id      = "${var.lpg_management2_oauth_client_id}"
+  lpg_management2_oauth_client_secret  = "${var.lpg_management2_oauth_client_secret}"
+  callback_url                        = "${var.callback_url}"
+}

--- a/environments/test/vars.tf
+++ b/environments/test/vars.tf
@@ -71,6 +71,10 @@ variable "lpg_report_service_docker_tag" {
   default = "feature-lpfg-370-booking-feed-csv-report-4"
 }
 
+variable "lpg_management2_tag" {
+  default = "latest"
+}
+
 ### cosmos ###
 variable "cosmos_name" {
   default = "cosmos"
@@ -214,4 +218,22 @@ variable "spring_profiles_active" {
 
 variable "identity_management_name" {
   default = "identity-management"
+}
+
+
+### lpg-management2 ###
+variable "lpg_management2_name" {
+  default = "lpg-management2"
+}
+
+variable "management2_hammer_working_directory" {
+  default = "/var/www/app/dist/management2"
+}
+
+variable "management2_websites_port" {
+  default = "3005"
+}
+
+variable "callback_url" {
+  default = "https://lpg-lpgtest-lpg-management2.azurewebsites.net"
 }

--- a/environments/test/vars.tf
+++ b/environments/test/vars.tf
@@ -226,14 +226,14 @@ variable "lpg_management2_name" {
   default = "lpg-management2"
 }
 
-variable "management2_hammer_working_directory" {
+variable "lpg_management2_hammer_working_directory" {
   default = "/var/www/app/dist/management2"
 }
 
-variable "management2_websites_port" {
+variable "lpg_management2_websites_port" {
   default = "3005"
 }
 
-variable "callback_url" {
+variable "lpg_management2_callback_url" {
   default = "https://lpg-lpgtest-lpg-management2.azurewebsites.net"
 }

--- a/modules/lpg-management2/main.tf
+++ b/modules/lpg-management2/main.tf
@@ -1,0 +1,132 @@
+###### identity-management ######
+
+resource "azurerm_template_deployment" "lpg-management2-app-service" {
+  name                = "${var.lpg_management2_name}"
+  resource_group_name = "${var.rg_name}"
+
+  template_body = <<DEPLOY
+  {
+      "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {
+          "siteName": {
+              "type": "string",
+              "defaultvalue": "${var.lpg_management2_name}",
+              "metadata": {
+                  "description": "Name of azure web app"
+              }
+          }
+      },
+      "variables": {
+          "hostingPlanName": "[concat(parameters('siteName'), 'serviceplan')]"
+      },
+      "resources": [
+          {
+              "type": "Microsoft.Web/sites",
+              "name": "[parameters('siteName')]",
+              "properties": {
+                  "siteConfig": {
+                      "appSettings": [
+            {
+              "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+              "value": "false"
+            },
+            {
+              "name": "HAMMER_LOGSTASH_HOST",
+              "value": "${var.hammer_logstash_host}"
+            },
+            {
+              "name": "HAMMER_LOGSTASH_PORT",
+              "value": "${var.hammer_logstash_port}"
+            },
+            {
+              "name": "ENV_PROFILE",
+              "value": "${var.env_profile}"
+            },
+            {
+              "name": "WEBSITES_PORT",
+              "value": "${var.websites_port}"
+            },
+            {
+              "name": "HAMMER_WORKING_DIRECTORY",
+              "value": "${var.hammer_working_directory}"
+            },
+            {
+              "name": "SESSION_SECRET",
+              "value": "${var.session_secret}"
+            },
+            {
+              "name": "DOCKER_ENABLE_CI",
+              "value": "true"
+            },
+            {
+              "name": "OAUTH_CLIENT_ID",
+              "value": "${var.lpg_management2_oauth_client_id}"
+            },
+            {
+              "name": "OAUTH_CLIENT_SECRET",
+              "value": "${var.lpg_management2_oauth_client_secret}"
+            },
+            {
+              "name": "CALLBACK_URL",
+              "value": "${var.callback_url}"
+            }
+          ]
+                  },
+                  "name": "[parameters('siteName')]",
+                  "serverFarmId": "[variables('hostingPlanName')]",
+                  "hostingEnvironment": ""
+              },
+              "apiVersion": "2016-03-01",
+              "location": "[resourceGroup().location]",
+              "tags" : {
+                  "environment": "${var.env_profile}"
+              },
+              "dependsOn": [
+                  "[variables('hostingPlanName')]"
+              ]
+          },
+          {
+              "apiVersion": "2016-09-01",
+              "name": "[variables('hostingPlanName')]",
+              "type": "Microsoft.Web/serverfarms",
+              "location": "[resourceGroup().location]",
+              "properties": {
+                  "name": "[variables('hostingPlanName')]",
+                  "workerSizeId": "1",
+                  "reserved": true,
+                  "numberOfWorkers": "1",
+                  "hostingEnvironment": ""
+              },
+              "sku": {
+                  "Tier": "${var.webapp_sku_tier}",
+                  "Name": "${var.webapp_sku_name}"
+              },
+              "kind": "linux"
+          },
+          {
+            "type": "Microsoft.Web/sites/config",
+            "name": "[concat(parameters('siteName'), '/web')]",
+            "apiVersion": "2016-08-01",
+            "location": "UK South",
+            "scale": null,
+            "properties": {
+                "httpLoggingEnabled": true,
+                "logsDirectorySizeLimit": 35,
+                "detailedErrorLoggingEnabled": true,
+                "alwaysOn": true,
+                "appCommandLine": "",
+                "linuxFxVersion": "DOCKER|${var.docker_image}:${var.docker_tag}",
+                "minTlsVersion": "1.0",
+                "ftpsState": "Disabled"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('siteName'))]"
+            ]
+        }
+      ]
+  }
+  DEPLOY
+
+  deployment_mode = "Incremental"
+}

--- a/modules/lpg-management2/vars.tf
+++ b/modules/lpg-management2/vars.tf
@@ -1,0 +1,95 @@
+variable "lpg_management2_name" {
+  default = "name"
+}
+
+variable "rg_name" {
+  default = "holder"
+}
+
+variable "rg_prefix" {
+  default = "rgpref"
+}
+
+variable "rg_location" {
+  default = "location"
+}
+
+variable "webapp_sku_tier" {
+  default = "Basic"
+}
+
+variable "webapp_sku_name" {
+  default = "B1"
+}
+
+variable "docker_tag" {
+  default = ""
+}
+
+variable "docker_image" {
+  default = "cshr/lpg-management-ui"
+}
+
+variable "authentication_service_url" {
+  default = ""
+}
+
+variable "hammer_logstash_host" {
+  default = "54e2fb5d-be7a-47c2-b3cf-6f72f42b5dfb-ls.logit.io"
+}
+
+variable "hammer_logstash_port" {
+  default = "16690"
+}
+
+variable "env_profile" {
+  default = "test"
+}
+
+variable "hammer_working_directory" {
+  default = ""
+}
+
+variable "websites_port" {
+  default = "3001"
+}
+
+variable "session_secret" {
+  default = ""
+}
+
+variable "envurl" {
+  default = "local"
+}
+
+variable "vaultresourcegroup" {
+  default = ""
+}
+
+variable "vaultname" {
+  default = ""
+}
+
+variable "existingkeyvaultsecretname" {
+  default = ""
+}
+
+variable "certificatename" {
+  default = ""
+}
+
+variable "lpg_management2_server" {
+  default = ""
+}
+
+variable "lpg_management2_oauth_client_id" {
+  default = ""
+}
+
+variable "lpg_management2_oauth_client_secret" {
+  default = ""
+}
+
+variable "callback_url" {
+  default = ""
+}


### PR DESCRIPTION
- adding config to set up service for the new LPG Management app
- calling it `lpg-management2` to avoid confusion with the existing management app, but we will want to clean up the name/refs in future
- just adding non-prod envs for now, prod can be done later