### PR TITLE
uv_threadpool_size Increase

### DIFF
--- a/modules/lpg-ui/main.tf
+++ b/modules/lpg-ui/main.tf
@@ -199,6 +199,10 @@ resource "azurerm_template_deployment" "lpg-ui-app-service" {
                               "value":"${var.feedback_recipient}"
                           },
                           {
+                              "name":"UV_THREADPOOL_SIZE",
+                              "value":"${var.uv_threadpool_size}"
+                          },
+                          {
                               "name":"DOCKER_REGISTRY_SERVER_URL",
                               "value":"https://${var.docker_registry_server_url}"
                           },

--- a/modules/lpg-ui/vars.tf
+++ b/modules/lpg-ui/vars.tf
@@ -146,6 +146,10 @@ variable "feedback_recipient" {
   default = ""
 }
 
+variable "uv_threadpool_size" {
+  default = "16"
+}
+
 variable "docker_registry_server_url" {
   default = ""
 }


### PR DESCRIPTION
As per https://nodejs.org/api/cli.html#cli_uv_threadpool_size_size - Increasing the default threadpool size for the frontend application to 16