### PR TITLE
Redis - Enable Non-SSL Port

### DIFF
--- a/modules/redis/vars.tf
+++ b/modules/redis/vars.tf
@@ -27,7 +27,7 @@ variable "redis_sku_name" {
 }
 
 variable "redis_enable_non_ssl_port" {
-  default = "false"
+  default = "true"
 }
 
 variable "redis_max_clients" {


### PR DESCRIPTION
Leaving existing configuration in place whilst support is added for session state to support TLS connections