### PR TITLE
Make modules compliant with Terraform v0.12

### DIFF
--- a/modules/blob/main.tf
+++ b/modules/blob/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_storage_account" "blobsa" {
   account_tier             = "${var.storage_account_tier}"
   account_replication_type = "${var.storage_account_replication}"
 
-  tags {
+  tags = {
     environment = "${var.env_profile}"
   }
 }

--- a/modules/cosmos/main.tf
+++ b/modules/cosmos/main.tf
@@ -16,7 +16,7 @@ resource "azurerm_cosmosdb_account" "test" {
     failover_priority = 0
   }
 
-  tags {
+  tags = {
     environment = "${var.env_profile}"
   }
 }

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_mysql_server" "lpg" {
   version                      = "5.7"
   ssl_enforcement              = "Enabled"
 
-  tags {
+  tags = {
     environment = "${var.env_profile}"
   }
 }

--- a/modules/mysql_generalpurpose/main.tf
+++ b/modules/mysql_generalpurpose/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_mysql_server" "lpg_gp" {
   version                      = "5.7"
   ssl_enforcement              = "Enabled"
 
-  tags {
+  tags = {
     environment = "${var.env_profile}"
   }
 }

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -15,7 +15,7 @@ resource "azurerm_redis_cache" "redis_cache" {
     maxmemory_policy   = "${var.redis_maxmemory_policy}"
   }
 
-  tags {
+  tags = {
     environment = "${var.env_profile}"
   }
 }


### PR DESCRIPTION
Change the **tags block** for modules that utilise it to be v0.12 compliant