### PR TITLE
Adding in Maintenance slots to identity and lpg-ui

### DIFF
--- a/environments/00-integration/00-vars.tf
+++ b/environments/00-integration/00-vars.tf
@@ -313,3 +313,20 @@ variable "content_container" {
 variable "notification_service_name" {
   default = "notification-service"
 }
+
+### maintenance window vars ###
+variable "maintenance_enabled" {
+  default = "false"
+}
+
+variable "maintenance_window_message" {
+  default = "message"
+}
+
+variable "maintenance_token_name" {
+  default = "token"
+}
+
+variable "maintenance_token_value" {
+  default = "token_value"
+}

--- a/environments/00-perf/00-vars.tf
+++ b/environments/00-perf/00-vars.tf
@@ -318,3 +318,20 @@ variable "notification_service_name" {
 variable "feedback_recipient" {
   default = "feedback@cslearning.gov.uk"
 }
+
+### maintenance window vars ###
+variable "maintenance_enabled" {
+  default = "false"
+}
+
+variable "maintenance_window_message" {
+  default = "message"
+}
+
+variable "maintenance_token_name" {
+  default = "token"
+}
+
+variable "maintenance_token_value" {
+  default = "token_value"
+}

--- a/environments/00-production/00-vars.tf
+++ b/environments/00-production/00-vars.tf
@@ -318,3 +318,20 @@ variable "notification_service_name" {
 variable "feedback_recipient" {
   default = "feedback@cslearning.gov.uk"
 }
+
+### maintenance window vars ###
+variable "maintenance_enabled" {
+  default = "false"
+}
+
+variable "maintenance_window_message" {
+  default = "message"
+}
+
+variable "maintenance_token_name" {
+  default = "token"
+}
+
+variable "maintenance_token_value" {
+  default = "token_value"
+}

--- a/environments/00-staging/00-vars.tf
+++ b/environments/00-staging/00-vars.tf
@@ -314,3 +314,20 @@ variable "content_container" {
 variable "notification_service_name" {
   default = "notification-service"
 }
+
+### maintenance window vars ###
+variable "maintenance_enabled" {
+  default = "false"
+}
+
+variable "maintenance_window_message" {
+  default = "message"
+}
+
+variable "maintenance_token_name" {
+  default = "token"
+}
+
+variable "maintenance_token_value" {
+  default = "token_value"
+}

--- a/environments/master/main.tf
+++ b/environments/master/main.tf
@@ -88,12 +88,16 @@ module "identity" {
   custom_emails                           = "${var.custom_emails}"
   webapp_sku_tier                         = "${var.webapp_sku_tier_p2}"
   webapp_sku_name                         = "${var.webapp_sku_name_p2}"
-  identity_capacity                         = "${var.identity_capacity}"
+  identity_capacity                       = "${var.identity_capacity}"
   docker_registry_server_url              = "${var.docker_registry_server_url}"
   docker_registry_server_username         = "${var.docker_registry_server_username}"
   docker_registry_server_password         = "${var.docker_registry_server_password}"
   authentication_service_url              = "https://${var.envurl}identity.${var.domain}"
   ai_instrument_key                       = "${var.ai_instrument_key}"
+  maintenance_enabled                     = "${var.maintenance_enabled}"
+  maintenance_window_message              = "${var.maintenance_window_message}"
+  maintenance_token_name                  = "${var.maintenance_token_name}"
+  maintenance_token_value                 = "${var.maintenance_token_value}"
 }
 
 module "identity-management" {
@@ -318,6 +322,10 @@ module "lpg-ui" {
   redis_host                      = "${module.redis-session.redis_host}"
   redis_password                  = "${module.redis-session.redis_key}"
   redis_port                      = "6379"
+  maintenance_enabled             = "${var.maintenance_enabled}"
+  maintenance_window_message      = "${var.maintenance_window_message}"
+  maintenance_token_name          = "${var.maintenance_token_name}"
+  maintenance_token_value         = "${var.maintenance_token_value}"
 }
 
 module "lpg-learning-catalogue" {

--- a/modules/identity/main.tf
+++ b/modules/identity/main.tf
@@ -202,6 +202,22 @@ resource "azurerm_template_deployment" "identity-app-service" {
                           {
                               "name":"DOCKER_REGISTRY_SERVER_PASSWORD",
                               "value":"${var.docker_registry_server_password}"
+                          },
+                          {
+                              "name":"MAINTENANCE_ENABLED",
+                              "value":"${var.maintenance_enabled}"
+                          },
+                          {
+                              "name":"MAINTENANCE_WINDOW_MESSAGE",
+                              "value":"${var.maintenance_window_message}"
+                          },
+                          {
+                              "name":"MAINTENANCE_TOKEN_NAME",
+                              "value":"${var.maintenance_token_name}"
+                          },
+                          {
+                              "name":"MAINTENANCE_TOKEN_VALUE",
+                              "value":"${var.maintenance_token_value}"
                           }
                       ]
                   },

--- a/modules/identity/vars.tf
+++ b/modules/identity/vars.tf
@@ -148,3 +148,20 @@ variable "scaling_enabled" {
 variable "authentication_service_url" {
   default = ""
 }
+
+### maintenance window vars ###
+variable "maintenance_enabled" {
+  default = "false"
+}
+
+variable "maintenance_window_message" {
+  default = "message"
+}
+
+variable "maintenance_token_name" {
+  default = "token"
+}
+
+variable "maintenance_token_value" {
+  default = "token_value"
+}

--- a/modules/lpg-ui/main.tf
+++ b/modules/lpg-ui/main.tf
@@ -230,6 +230,22 @@ resource "azurerm_template_deployment" "lpg-ui-app-service" {
                           {
                               "name":"DOCKER_REGISTRY_SERVER_PASSWORD",
                               "value":"${var.docker_registry_server_password}"
+                          },
+                          {
+                              "name":"MAINTENANCE_ENABLED",
+                              "value":"${var.maintenance_enabled}"
+                          },
+                          {
+                              "name":"MAINTENANCE_WINDOW_MESSAGE",
+                              "value":"${var.maintenance_window_message}"
+                          },
+                          {
+                              "name":"MAINTENANCE_TOKEN_NAME",
+                              "value":"${var.maintenance_token_name}"
+                          },
+                          {
+                              "name":"MAINTENANCE_TOKEN_VALUE",
+                              "value":"${var.maintenance_token_value}"
                           }
                       ]
                   },

--- a/modules/lpg-ui/vars.tf
+++ b/modules/lpg-ui/vars.tf
@@ -188,3 +188,20 @@ variable "custom_emails" {
 variable "scaling_enabled" {
   default = ""
 }
+
+### maintenance window vars ###
+variable "maintenance_enabled" {
+  default = "false"
+}
+
+variable "maintenance_window_message" {
+  default = "message"
+}
+
+variable "maintenance_token_name" {
+  default = "token"
+}
+
+variable "maintenance_token_value" {
+  default = "token_value"
+}


### PR DESCRIPTION
Only for merge once the image changes have been made.

Currently no deployment slots, just the extra variables that we can use to customise the maintenance page and switch on. 