### PR TITLE
Increased heap size for learner record

### DIFF
--- a/modules/lpg-learner-record/main.tf
+++ b/modules/lpg-learner-record/main.tf
@@ -255,7 +255,7 @@ resource "azurerm_template_deployment" "lpg-learner-record-app-service" {
                   "logsDirectorySizeLimit":35,
                   "detailedErrorLoggingEnabled":true,
                   "alwaysOn":true,
-                  "appCommandLine":"/bin/hammer java -Xms1g -Xmx4g -javaagent:/opt/appinsights/applicationinsights-agent-2.5.0.jar -jar /data/app.jar",
+                  "appCommandLine":"/bin/hammer java -Xms3g -Xmx12g -javaagent:/opt/appinsights/applicationinsights-agent-2.5.0.jar -jar /data/app.jar",
                   "linuxFxVersion":"DOCKER|${var.docker_registry_server_url}/${var.docker_image}:${var.docker_tag}",
                   "minTlsVersion":"1.2",
                   "ftpsState":"Disabled"

--- a/modules/lpg-learner-record/main.tf
+++ b/modules/lpg-learner-record/main.tf
@@ -255,7 +255,7 @@ resource "azurerm_template_deployment" "lpg-learner-record-app-service" {
                   "logsDirectorySizeLimit":35,
                   "detailedErrorLoggingEnabled":true,
                   "alwaysOn":true,
-                  "appCommandLine":"/bin/hammer java -Xms3g -Xmx12g -javaagent:/opt/appinsights/applicationinsights-agent-2.5.0.jar -jar /data/app.jar",
+                  "appCommandLine":"/bin/hammer java -Xms3g -Xmx7g -javaagent:/opt/appinsights/applicationinsights-agent-2.5.0.jar -jar /data/app.jar",
                   "linuxFxVersion":"DOCKER|${var.docker_registry_server_url}/${var.docker_image}:${var.docker_tag}",
                   "minTlsVersion":"1.2",
                   "ftpsState":"Disabled"

--- a/modules/lpg-learner-record/main.tf
+++ b/modules/lpg-learner-record/main.tf
@@ -255,7 +255,7 @@ resource "azurerm_template_deployment" "lpg-learner-record-app-service" {
                   "logsDirectorySizeLimit":35,
                   "detailedErrorLoggingEnabled":true,
                   "alwaysOn":true,
-                  "appCommandLine":"/bin/hammer java -javaagent:/opt/appinsights/applicationinsights-agent-2.5.0.jar -jar /data/app.jar",
+                  "appCommandLine":"/bin/hammer java -Xms1g -Xmx4g -javaagent:/opt/appinsights/applicationinsights-agent-2.5.0.jar -jar /data/app.jar",
                   "linuxFxVersion":"DOCKER|${var.docker_registry_server_url}/${var.docker_image}:${var.docker_tag}",
                   "minTlsVersion":"1.2",
                   "ftpsState":"Disabled"


### PR DESCRIPTION
Increased initial java heap size to 1GB and maximum heap size to 4GB for learner record.