### PR TITLE
Update environment variables for account reactivation

### DIFF
--- a/environments/00-integration/00-vars.tf
+++ b/environments/00-integration/00-vars.tf
@@ -389,3 +389,7 @@ variable "maintenance_page_content_line_4" {
 variable "backend_api_call_batch_size" {
   default = "50"
 }
+
+variable "identity_base_url" {
+  default = "https://identity.integration.learn.civilservice.gov.uk"
+}

--- a/environments/00-integration/docker-tags-vars.tf
+++ b/environments/00-integration/docker-tags-vars.tf
@@ -13,7 +13,6 @@ variable "civil_servant_registry_docker_repository_region" {
 variable "identity_docker_tag" {
   default = "idt-develop"
 }
-
 variable "identity_docker_repository_region" {
   default = "test"
 }

--- a/environments/00-perf/00-vars.tf
+++ b/environments/00-perf/00-vars.tf
@@ -393,3 +393,7 @@ variable "maintenance_page_content_line_4" {
 variable "backend_api_call_batch_size" {
   default = "50"
 }
+
+variable "identity_base_url" {
+  default = "https://identity.performance.learn.civilservice.gov.uk"
+}

--- a/environments/00-production/00-vars.tf
+++ b/environments/00-production/00-vars.tf
@@ -392,3 +392,7 @@ variable "maintenance_page_content_line_4" {
 variable "backend_api_call_batch_size" {
   default = "50"
 }
+
+variable "identity_base_url" {
+  default = "https://identity.learn.civilservice.gov.uk"
+}

--- a/environments/00-staging/00-vars.tf
+++ b/environments/00-staging/00-vars.tf
@@ -388,3 +388,7 @@ variable "maintenance_page_content_line_4" {
 variable "backend_api_call_batch_size" {
   default = "50"
 }
+
+variable "identity_base_url" {
+  default = "https://identity.staging.learn.civilservice.gov.uk"
+}

--- a/environments/master/main.tf
+++ b/environments/master/main.tf
@@ -116,6 +116,9 @@ module "identity" {
   maintenance_page_content_line_3         = var.maintenance_page_content_line_3
   maintenance_page_content_line_4         = var.maintenance_page_content_line_4
   application_insights_connection_string = var.application_insights_connection_string
+  identity_base_url = var.identity_base_url
+  email_template_url = var.email_template_url
+  encryption_key = var.encryption_key
 }
 
 module "identity-management" {

--- a/modules/identity/main.tf
+++ b/modules/identity/main.tf
@@ -238,6 +238,18 @@ resource "azurerm_template_deployment" "identity-app-service" {
                           {
                               "name":"MAINTENANCE_PAGE_CONTENT_LINE_4",
                               "value":"${var.maintenance_page_content_line_4}"
+                          },
+                          {
+                              "name":"IDENTITY_BASE_URL",
+                              "value":"${var.identity_base_url}"
+                          },
+                          {
+                              "name":"EMAIL_TEMPLATE_ID",
+                              "value":"${var.email_template_url}"
+                          },
+                          {
+                              "name":"ENCRYPTION_KEY",
+                              "value":"${var.encryption_key}"
                           }
                       ],
                       "healthCheckPath": "/health"

--- a/modules/identity/vars.tf
+++ b/modules/identity/vars.tf
@@ -187,3 +187,15 @@ variable "maintenance_page_content_line_3" {
 variable "maintenance_page_content_line_4" {
   default = "If the maintenance period is extended, further information will be provided here."
 }
+
+variable "identity_base_url" {
+  default = ""
+}
+
+variable "email_template_url" {
+  default = ""
+}
+
+variable "encryption_key" {
+  default = ""
+}


### PR DESCRIPTION
This change adds 3 new environment variables used for the account reactication workflow:

* `identity_base_url` used to add the correct link in the reactivation email
* `email_template_url` used to send the reactivation email based on a GovNotify template
* `encryption_key` used to hash email from the URL.