### PR TITLE
LC 1422 fix terraform implementation

### DIFF
--- a/environments/00-integration/docker-tags-vars.tf
+++ b/environments/00-integration/docker-tags-vars.tf
@@ -20,7 +20,7 @@ variable "identity_docker_repository_region" {
 ## identity-management ##
 
 variable "identity_management_docker_tag" {
-  default = "idt-feature-LC-1100-refactor-data-retention"
+  default = "idt-develop"
 }
 
 variable "identity_management_docker_repository_region" {
@@ -46,7 +46,7 @@ variable "lpg_learner_record_docker_repository_region" {
 ## learning-catalogue ##
 
 variable "learning_catalogue_docker_tag" {
-  default = "idt-develop"
+  default = "idt-feature-LC-1430-es-cloud-poc"
 }
 
 variable "learning_catalogue_docker_repository_region" {
@@ -56,7 +56,7 @@ variable "learning_catalogue_docker_repository_region" {
 ## lpg-management ##
 
 variable "lpg_management_tag" {
-  default = "master"
+  default = "idt-develop"
 }
 
 variable "lpg_management_docker_repository_region" {
@@ -80,7 +80,7 @@ variable "lpg_services_docker_repository_region" {
 }
 
 variable "lpg_services_tag" {
-  default = "idt-feature-LC-1094-update-servicedesk-email"
+  default = "idt-develop"
 }
 
 ## notification-service ##

--- a/environments/master/main.tf
+++ b/environments/master/main.tf
@@ -60,14 +60,14 @@ module "cosmos" {
   env_profile = var.env_profile
 }
 
-module "blob" {
-  source               = "../../modules/blob"
-  rg_name              = var.rg_name
-  rg_prefix            = var.rg_prefix
-  rg_location          = var.rg_location
-  storage_account_name = "${var.rg_prefix}${var.rg_name}blob"
-  env_profile          = var.env_profile
-}
+#module "blob" {
+#  source               = "../../modules/blob"
+#  rg_name              = var.rg_name
+#  rg_prefix            = var.rg_prefix
+#  rg_location          = var.rg_location
+#  storage_account_name = "${var.rg_prefix}${var.rg_name}blob"
+#  env_profile          = var.env_profile
+#}
 
 module "identity" {
   source                                  = "../../modules/identity"
@@ -241,7 +241,7 @@ module "lpg-learning-locker-xapi" {
   rg_location                     = var.rg_location
   learning_locker_xapi_name       = "${var.rg_prefix}-${var.rg_name}-${var.lpg_learning_locker_xapi_name}"
   domain                          = var.domain
-  mongo_url                       = "mongodb://${module.cosmos.cosmos_name}:${module.cosmos.cosmos_password}@${module.cosmos.cosmos_name}.mongo.cosmos.azure.com:10255/?ssl=true&retrywrites=false"
+  mongo_url                       = "mongodb://${module.cosmos.cosmos_name}:${module.cosmos.cosmos_password}@${module.cosmos.cosmos_name}.mongo.cosmos.azure.com:10255/?ssl=true&retrywrites=false&appName=@lpg-lpgprod-cosmos@"
   redis_url                       = "redis://${module.redis.redis_host}:${module.redis.redis_port}/0?password=${module.redis.redis_key}"
   docker_tag                      = var.ll_docker_tag
   env_profile                     = var.env_profile

--- a/environments/master/main.tf
+++ b/environments/master/main.tf
@@ -241,7 +241,7 @@ module "lpg-learning-locker-xapi" {
   rg_location                     = var.rg_location
   learning_locker_xapi_name       = "${var.rg_prefix}-${var.rg_name}-${var.lpg_learning_locker_xapi_name}"
   domain                          = var.domain
-  mongo_url                       = "mongodb://${module.cosmos.cosmos_name}:${module.cosmos.cosmos_password}@${module.cosmos.cosmos_name}.mongo.cosmos.azure.com:10255/?ssl=true&retrywrites=false&appName=@lpg-lpgprod-cosmos@"
+  mongo_url                       = "mongodb://${module.cosmos.cosmos_name}:${module.cosmos.cosmos_password}@${module.cosmos.cosmos_name}.mongo.cosmos.azure.com:10255/?ssl=true&retrywrites=false&appName=@${module.cosmos.cosmos_name}@"
   redis_url                       = "redis://${module.redis.redis_host}:${module.redis.redis_port}/0?password=${module.redis.redis_key}"
   docker_tag                      = var.ll_docker_tag
   env_profile                     = var.env_profile

--- a/modules/cosmos/main.tf
+++ b/modules/cosmos/main.tf
@@ -8,6 +8,8 @@ resource "azurerm_cosmosdb_account" "test" {
   offer_type          = var.cosmos_offer_type
   kind                = "MongoDB"
 
+  default_identity_type = "FirstPartyIdentity"
+
 
 # AllowSelfServeUpgradeToMongo36 
   capabilities {

--- a/modules/mysql_generalpurpose/main.tf
+++ b/modules/mysql_generalpurpose/main.tf
@@ -5,19 +5,27 @@ resource "azurerm_mysql_server" "lpg_gp" {
   location            = var.mysql_location
   resource_group_name = var.rg_name
 
+  create_mode = "Default"
+
   sku_name = var.lpg_gp_skumname
 
-  storage_profile {
-    storage_mb = var.mysql_storage
-    backup_retention_days = 30
-    geo_redundant_backup = "Disabled"
-    auto_grow = "Disabled"
+  storage_mb = var.mysql_storage
+  backup_retention_days = 30
+  geo_redundant_backup_enabled = false
+  auto_grow_enabled = false
+
+  threat_detection_policy {
+    disabled_alerts = []
+    email_account_admins = false
+    email_addresses = []
+    enabled = true
+    retention_days = 0
   }
 
   administrator_login          = var.mysql_admin_login
   administrator_login_password = var.mysql_admin_pass
   version                      = "5.7"
-  ssl_enforcement              = "Enabled"
+  ssl_enforcement_enabled              = true
 
   tags = {
     environment = var.env_profile

--- a/scripts/cosmos/fix_default_identity_type.sh
+++ b/scripts/cosmos/fix_default_identity_type.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+# Forces the default-identity parameter to be not-null in cosmos.
+# This is required to fix the default_identity_type bug, wherein
+# Terraform will repeatedly attempt to set  default_identity_type
+# to FirstPartyIdentity, but the actual MS ARM API will override and
+# set to null. Context: https://github.com/hashicorp/terraform-provider-azurerm/issues/14439
+
+RESOURCE_GROUP=$1
+COSMOS_DB_NAME=$2
+
+echo creating SystemAssignedIdentity
+az cosmosdb identity assign -g "${RESOURCE_GROUP}" -n "${COSMOS_DB_NAME}"
+echo setting default identities
+az cosmosdb update -g "${RESOURCE_GROUP}" -n "${COSMOS_DB_NAME}" --default-identity SystemAssignedIdentity
+az cosmosdb update -g "${RESOURCE_GROUP}" -n "${COSMOS_DB_NAME}" --default-identity FirstPartyIdentity
+echo removing SystemAssignedIdentity
+az cosmosdb identity remove -g "${RESOURCE_GROUP}" -n "${COSMOS_DB_NAME}"


### PR DESCRIPTION
- Comment out blob storage
- Update resources for AzureRM provider 3.0
- Add missing connection string detail on xAPI mongo string
- Add fix (and script) for `default_identity_type` in cosmosDB resources

When using `terraform plan` with this change for the first time in a new environment, the following commands must be executed:

`terraform state rm 'module.blob.azurerm_storage_account.blobsa'`

`terraform state rm 'module.blob.azurerm_storage_container.blobc'`

This is due to a bug with the blob storage being outdated and the SKU/replication type being mismatched as a result. The above commands remove the blob storage from the terraform plan. The blob storage can be added back in (correctly) in the future, but will require a migration plan from the existing blob to the new one. For now, the blob storage container can be managed outside of Terraform.