### PR TITLE
LC 1422 fix terraform cosmos primary key

### DIFF
--- a/modules/cosmos/main.tf
+++ b/modules/cosmos/main.tf
@@ -43,7 +43,7 @@ resource "azurerm_cosmosdb_account" "test" {
 }
 
 output "cosmos_password" {
-  value = azurerm_cosmosdb_account.test.primary_master_key
+  value = azurerm_cosmosdb_account.test.primary_key
 }
 output "cosmos_name" {
   value = azurerm_cosmosdb_account.test.name

--- a/modules/mysql_generalpurpose/main.tf
+++ b/modules/mysql_generalpurpose/main.tf
@@ -13,6 +13,7 @@ resource "azurerm_mysql_server" "lpg_gp" {
   backup_retention_days = 30
   geo_redundant_backup_enabled = false
   auto_grow_enabled = false
+  ssl_minimal_tls_version_enforced = "TLSEnforcementDisabled"
 
   threat_detection_policy {
     disabled_alerts = []

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -8,6 +8,7 @@ resource "azurerm_redis_cache" "redis_cache" {
   family              = var.redis_family
   sku_name            = var.redis_sku_name
   enable_non_ssl_port = var.redis_enable_non_ssl_port
+  minimum_tls_version = "1.0"
   
   redis_configuration {
     maxmemory_reserved = var.redis_maxmemory_reserved


### PR DESCRIPTION
- `primary_master_key` is deprecated in newer versions of AzureRM; it now uses `primary_key`
- TLS versions will default to 1.2 (suspected recent Azure update) - 1.2 currently breaks the Java apps so force them back to 1.0 **for now. This will need looking at very soon**.