### PR TITLE
LC-1938 redis updates

### DIFF
--- a/environments/integration/vars.tf
+++ b/environments/integration/vars.tf
@@ -28,16 +28,30 @@ variable "env_profile" {
 	default =  "integration"
 }
 
+## Redis
+
 variable "redis_session_capacity" {
 	default =  "0"
+}
+
+variable "redis_session_family" {
+	default =  "C"
 }
 
 variable "redis_org_capacity" {
 	default =  "0"
 }
 
+variable "redis_org_family" {
+	default =  "C"
+}
+
 variable "redis_csl_service_capacity" {
 	default =  "0"
+}
+
+variable "redis_csl_service_family" {
+	default =  "C"
 }
 
 ## Identity

--- a/environments/master/main.tf
+++ b/environments/master/main.tf
@@ -11,6 +11,7 @@ module "redis-session" {
   redis_name     = "${var.rg_prefix}-${var.rg_name}-redis-session"
   env_profile    = var.env_profile
   redis_capacity = var.redis_session_capacity
+  redis_family   = var.redis_session_family
   allowed_ips = toset(concat(
 		local.lpg_ui_ips,
 		local.lpg_management_ips,
@@ -26,6 +27,7 @@ module "redis-org" {
   redis_name     = "${var.rg_prefix}-${var.rg_name}-redis-org"
   env_profile    = var.env_profile
   redis_capacity = var.redis_org_capacity
+  redis_family   = var.redis_org_family
   allowed_ips = toset(concat(
 		local.lpg_ui_ips,
 		local.lpg_management_ips
@@ -40,6 +42,7 @@ module "redis-csl-service" {
   redis_name     = "${var.rg_prefix}-${var.rg_name}-redis-csl-service"
   env_profile    = var.env_profile
   redis_capacity = var.redis_csl_service_capacity
+  redis_family   = var.redis_csl_service_family
   allowed_ips = toset(concat(
 		module.csl_service.ip_addresses
 	))

--- a/environments/perf/vars.tf
+++ b/environments/perf/vars.tf
@@ -35,15 +35,27 @@ variable "env_profile" {
 ### redis ###
 
 variable "redis_session_capacity" {
-  default = "1"
+  default =  "1"
+}
+
+variable "redis_session_family" {
+  default =  "P"
 }
 
 variable "redis_org_capacity" {
-  default = "1"
+  default =  "1"
+}
+
+variable "redis_org_family" {
+  default =  "P"
 }
 
 variable "redis_csl_service_capacity" {
-  default = "1"
+  default =  "1"
+}
+
+variable "redis_csl_service_family" {
+  default =  "P"
 }
 
 ## Identity

--- a/environments/production/vars.tf
+++ b/environments/production/vars.tf
@@ -35,15 +35,27 @@ variable "env_profile" {
 ### redis ###
 
 variable "redis_session_capacity" {
-  default = "1"
+  default =  "1"
+}
+
+variable "redis_session_family" {
+  default =  "P"
 }
 
 variable "redis_org_capacity" {
-  default = "1"
+  default =  "1"
+}
+
+variable "redis_org_family" {
+  default =  "P"
 }
 
 variable "redis_csl_service_capacity" {
-  default = "1"
+  default =  "1"
+}
+
+variable "redis_csl_service_family" {
+  default =  "P"
 }
 
 ## Identity

--- a/environments/staging/vars.tf
+++ b/environments/staging/vars.tf
@@ -28,16 +28,30 @@ variable "env_profile" {
   default = "staging"
 }
 
+## Redis
+
 variable "redis_session_capacity" {
-  default = "0"
+	default =  "0"
+}
+
+variable "redis_session_family" {
+	default =  "C"
 }
 
 variable "redis_org_capacity" {
-  default = "0"
+	default =  "0"
+}
+
+variable "redis_org_family" {
+	default =  "C"
 }
 
 variable "redis_csl_service_capacity" {
-  default = "0"
+	default =  "0"
+}
+
+variable "redis_csl_service_family" {
+	default =  "C"
 }
 
 ## Identity

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -6,11 +6,12 @@ resource "azurerm_redis_cache" "redis_cache" {
   resource_group_name = var.rg_name
   capacity            = var.redis_capacity
   family              = var.redis_family
-  sku_name            = var.redis_sku_name
+  sku_name            = var.redis_family == "C" ? "Standard" : "Premium"
   enable_non_ssl_port = var.redis_enable_non_ssl_port
   minimum_tls_version = "1.0"
-  
+
   redis_configuration {
+    rdb_backup_enabled = false
     maxmemory_reserved = var.redis_maxmemory_reserved
     maxmemory_delta    = var.redis_maxmemory_delta
     maxmemory_policy   = var.redis_maxmemory_policy
@@ -23,7 +24,7 @@ resource "azurerm_redis_cache" "redis_cache" {
 
 resource "azurerm_redis_firewall_rule" "firewall_rules" {
 	for_each 			= var.allowed_ips
-	name                = replace(each.value, ".", "_")
+	name                = replace(each.value, ".", "")
 	redis_cache_name    = azurerm_redis_cache.redis_cache.name
 	resource_group_name = var.rg_name
 	start_ip            = each.value

--- a/modules/redis/vars.tf
+++ b/modules/redis/vars.tf
@@ -22,10 +22,6 @@ variable "redis_family" {
   default = "C"
 }
 
-variable "redis_sku_name" {
-  default = "Standard"
-}
-
 variable "redis_enable_non_ssl_port" {
   default = "true"
 }


### PR DESCRIPTION
- Firewall rule names can no longer contain underscores, so just squash the IPs for the name instead
- General redis updates for premium tiers in performance/live