### PR TITLE
LC 2042 redis config

### DIFF
--- a/environments/perf/vars.tf
+++ b/environments/perf/vars.tf
@@ -39,7 +39,7 @@ variable "redis_session_capacity" {
 }
 
 variable "redis_session_family" {
-  default =  "P"
+  default =  "C"
 }
 
 variable "redis_org_capacity" {
@@ -47,7 +47,7 @@ variable "redis_org_capacity" {
 }
 
 variable "redis_org_family" {
-  default =  "P"
+  default =  "C"
 }
 
 variable "redis_csl_service_capacity" {
@@ -55,7 +55,7 @@ variable "redis_csl_service_capacity" {
 }
 
 variable "redis_csl_service_family" {
-  default =  "P"
+  default =  "C"
 }
 
 ## Identity

--- a/environments/production/state.tf
+++ b/environments/production/state.tf
@@ -3,7 +3,7 @@ terraform {
   backend "azurerm" {
     storage_account_name  = "lpgterraformsecure"
     container_name        = "tfstatesecure"
-    key                   = "prod.terraform-new.tfstate"
+    key                   = "prod.terraform.tfstate"
 	resource_group_name = "lpgterraform"
   }
 }

--- a/environments/production/vars.tf
+++ b/environments/production/vars.tf
@@ -39,7 +39,7 @@ variable "redis_session_capacity" {
 }
 
 variable "redis_session_family" {
-  default =  "P"
+  default =  "C"
 }
 
 variable "redis_org_capacity" {
@@ -47,7 +47,7 @@ variable "redis_org_capacity" {
 }
 
 variable "redis_org_family" {
-  default =  "P"
+  default =  "C"
 }
 
 variable "redis_csl_service_capacity" {
@@ -55,7 +55,7 @@ variable "redis_csl_service_capacity" {
 }
 
 variable "redis_csl_service_family" {
-  default =  "P"
+  default =  "C"
 }
 
 ## Identity


### PR DESCRIPTION
- Scaled redis down as the P tiers are far more expensive
- Removed configuration option that was causing a bug
- Correct state